### PR TITLE
Persist the RequestStore at job execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ run MyRackApp
 
 ```ruby
 RequestStore::Sidekiq.configure do |config|
-  # Enable store restoring a job execution.
-  config.restore = true
+  # Enable store persistance at job execution.
+  config.persist = true
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ RequestStore::Sidekiq.add_custom_middleware!
 run MyRackApp
 ```
 
+## Configuration
+
+```ruby
+RequestStore::Sidekiq.configure do |config|
+  # Enable store restoring a job execution.
+  config.restore = true
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/request_store/sidekiq.rb
+++ b/lib/request_store/sidekiq.rb
@@ -2,15 +2,34 @@ require "request_store"
 require "sidekiq"
 
 require "request_store/sidekiq/version"
+require "request_store/sidekiq/configuration"
+require "request_store/sidekiq/client_middleware"
 require "request_store/sidekiq/server_middleware"
 require "request_store/sidekiq/railtie" if defined?(Rails::Railtie)
 
 module RequestStore
   module Sidekiq
     def self.add_custom_middleware!
+      ::Sidekiq.configure_client do |config|
+        config.client_middleware do |chain|
+          chain.add ::RequestStore::Sidekiq::ClientMiddleware
+        end
+      end
+
       ::Sidekiq.configure_server do |config|
+        config.client_middleware do |chain|
+          chain.add ::RequestStore::Sidekiq::ClientMiddleware
+        end
+
         config.server_middleware do |chain|
-          chain.add ServerMiddleware
+          if defined?(::Sidekiq::Batch::Server)
+            chain.insert_before(
+              ::Sidekiq::Batch::Server,
+              ::RequestStore::Sidekiq::ServerMiddleware
+            )
+          else
+            chain.add ::RequestStore::Sidekiq::ServerMiddleware
+          end
         end
       end
     end

--- a/lib/request_store/sidekiq/client_middleware.rb
+++ b/lib/request_store/sidekiq/client_middleware.rb
@@ -10,7 +10,7 @@ module RequestStore
       end
 
       def store_request_store?(item)
-        ::RequestStore::Sidekiq.configuration.restore &&
+        ::RequestStore::Sidekiq.configuration.persist &&
           item['request_store'].blank?
       end
     end

--- a/lib/request_store/sidekiq/client_middleware.rb
+++ b/lib/request_store/sidekiq/client_middleware.rb
@@ -1,0 +1,18 @@
+module RequestStore
+  module Sidekiq
+    class ClientMiddleware
+      def call(_worker_class, item, _queue, _redis_pool = nil)
+        if store_request_store?(item)
+          item['request_store'] = ::RequestStore.store
+        end
+
+        yield
+      end
+
+      def store_request_store?(item)
+        ::RequestStore::Sidekiq.configuration.restore &&
+          item['request_store'].blank?
+      end
+    end
+  end
+end

--- a/lib/request_store/sidekiq/configuration.rb
+++ b/lib/request_store/sidekiq/configuration.rb
@@ -1,0 +1,25 @@
+# Engine configuration.
+module RequestStore
+  module Sidekiq
+    class << self
+      attr_writer :configuration
+
+      def configuration
+        @configuration ||= Configuration.new
+      end
+
+      def configure
+        yield(configuration)
+      end
+    end
+
+    # Configuration variables and defaults.
+    class Configuration
+      attr_accessor :restore
+
+      def initialize
+        @restore = false
+      end
+    end
+  end
+end

--- a/lib/request_store/sidekiq/configuration.rb
+++ b/lib/request_store/sidekiq/configuration.rb
@@ -15,10 +15,10 @@ module RequestStore
 
     # Configuration variables and defaults.
     class Configuration
-      attr_accessor :restore
+      attr_accessor :persist
 
       def initialize
-        @restore = false
+        @persist = false
       end
     end
   end

--- a/lib/request_store/sidekiq/server_middleware.rb
+++ b/lib/request_store/sidekiq/server_middleware.rb
@@ -12,7 +12,7 @@ module RequestStore
       end
 
       def restore_request_store?(job)
-        ::RequestStore::Sidekiq.configuration.restore &&
+        ::RequestStore::Sidekiq.configuration.persist &&
           job['request_store'].present?
       end
     end

--- a/lib/request_store/sidekiq/server_middleware.rb
+++ b/lib/request_store/sidekiq/server_middleware.rb
@@ -1,10 +1,19 @@
 module RequestStore
   module Sidekiq
     class ServerMiddleware
-      def call(worker, job, queue)
+      def call(_worker, job, _queue)
+        if restore_request_store?(job)
+          ::RequestStore.store.merge!(job['request_store'])
+        end
+
         yield
       ensure
         ::RequestStore.clear!
+      end
+
+      def restore_request_store?(job)
+        ::RequestStore::Sidekiq.configuration.restore &&
+          job['request_store'].present?
       end
     end
   end

--- a/spec/request_store/sidekiq/server_middleware_spec.rb
+++ b/spec/request_store/sidekiq/server_middleware_spec.rb
@@ -14,19 +14,19 @@ RSpec.describe RequestStore::Sidekiq::ServerMiddleware do
     end
   end
 
-  shared_examples 'a restored request store' do
+  shared_examples 'a persisted request store' do
     before do
       # ClientMiddleware setup the store.
       job['request_store'] = store
     end
 
-    context 'when restoring is enabled' do
+    context 'when persistance is enabled' do
       before do
-        ::RequestStore::Sidekiq.configure { |config| config.restore = true }
+        ::RequestStore::Sidekiq.configure { |config| config.persist = true }
       end
 
       after do
-        ::RequestStore::Sidekiq.configure { |config| config.restore = false }
+        ::RequestStore::Sidekiq.configure { |config| config.persist = false }
       end
 
       it 'restores the request store' do
@@ -36,7 +36,7 @@ RSpec.describe RequestStore::Sidekiq::ServerMiddleware do
       end
     end
 
-    context 'when restoring is disabled' do
+    context 'when persistance is disabled' do
       it 'do not restores the request store' do
         subject.call(worker, job, queue) do
           expect(::RequestStore.store).to eq({})
@@ -54,7 +54,7 @@ RSpec.describe RequestStore::Sidekiq::ServerMiddleware do
     end
 
     it_behaves_like 'a cleared request store'
-    it_behaves_like 'a restored request store'
+    it_behaves_like 'a persisted request store'
   end
 
   context 'when the worker completes successfully' do
@@ -66,6 +66,6 @@ RSpec.describe RequestStore::Sidekiq::ServerMiddleware do
     end
 
     it_behaves_like 'a cleared request store'
-    it_behaves_like 'a restored request store'
+    it_behaves_like 'a persisted request store'
   end
 end

--- a/spec/request_store/sidekiq/server_middleware_spec.rb
+++ b/spec/request_store/sidekiq/server_middleware_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 RSpec.describe RequestStore::Sidekiq::ServerMiddleware do
-  let(:worker)  { class_double('Worker') }
-  let(:job)     { Hash.new }
-  let(:queue)   { 'default' }
+  let(:worker) { class_double('Worker') }
+  let(:job)    { {} }
+  let(:queue)  { 'default' }
+  let(:store)  { { a: 1 } }
 
   shared_examples 'a cleared request store' do
     it 'clears the request store' do
@@ -13,19 +14,58 @@ RSpec.describe RequestStore::Sidekiq::ServerMiddleware do
     end
   end
 
+  shared_examples 'a restored request store' do
+    before do
+      # ClientMiddleware setup the store.
+      job['request_store'] = store
+    end
+
+    context 'when restoring is enabled' do
+      before do
+        ::RequestStore::Sidekiq.configure { |config| config.restore = true }
+      end
+
+      after do
+        ::RequestStore::Sidekiq.configure { |config| config.restore = false }
+      end
+
+      it 'restores the request store' do
+        subject.call(worker, job, queue) do
+          expect(::RequestStore.store).to eq(store)
+        end
+      end
+    end
+
+    context 'when restoring is disabled' do
+      it 'do not restores the request store' do
+        subject.call(worker, job, queue) do
+          expect(::RequestStore.store).to eq({})
+        end
+      end
+    end
+  end
+
   context 'when the worker raises an error' do
     before do
-      allow_any_instance_of(worker).to receive(:perform).and_raise(ArgumentError)
+      allow_any_instance_of(worker).to(
+        receive(:perform)
+          .and_raise(ArgumentError)
+      )
     end
 
     it_behaves_like 'a cleared request store'
+    it_behaves_like 'a restored request store'
   end
 
   context 'when the worker completes successfully' do
     before do
-      allow_any_instance_of(worker).to receive(:perform).and_return(true)
+      allow_any_instance_of(worker).to(
+        receive(:perform)
+          .and_return(true)
+      )
     end
 
     it_behaves_like 'a cleared request store'
+    it_behaves_like 'a restored request store'
   end
 end

--- a/spec/request_store/sidekiq_spec.rb
+++ b/spec/request_store/sidekiq_spec.rb
@@ -16,7 +16,17 @@ describe RequestStore::Sidekiq do
     it 'added our middleware to the server stack' do
       subject.add_custom_middleware!
 
-      expect(::Sidekiq.server_middleware).to be_exists(RequestStore::Sidekiq::ServerMiddleware)
+      expect(::Sidekiq.server_middleware).to(
+        be_exists(RequestStore::Sidekiq::ServerMiddleware)
+      )
+    end
+
+    it 'added our middleware to the client stack' do
+      subject.add_custom_middleware!
+
+      expect(::Sidekiq.client_middleware).to(
+        be_exists(RequestStore::Sidekiq::ClientMiddleware)
+      )
     end
   end
 end


### PR DESCRIPTION
If the `persist` feature is active: 

```ruby
RequestStore::Sidekiq.configure do |config|
  # Enable store persistance a job execution.
  config.persist = true
end
```

The `RequestStore.store` is saved and restored at job execution.

**It allows you to save the store for retried jobs or keep the same store for jobs pushed by another job with a store.**