### PR TITLE
Add GitHub Actions CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  pull_request:
+
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby:
+          - 2.6
+          - 2.7
+          - '3.0'
+          - 3.1
+          - ruby-head
+          - jruby-9.2
+          - jruby-9.3
+          - jruby-head
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # 'bundle install' and cache
+    - name: Test
+      run: bundle exec rake

--- a/request_store-sidekiq.gemspec
+++ b/request_store-sidekiq.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency "request_store", ">= 1.3"
   spec.add_dependency "sidekiq", ">= 3.0"
 
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 1.13"
+  spec.add_development_dependency "rake", ">= 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "byebug", "~> 9.0"
   spec.add_development_dependency 'combustion', '~> 0.5.5'


### PR DESCRIPTION
This introduces a CI configuration for GitHub Actions.

- looser dev deps for Bundler, Rake

After merge: change the build status badge in the README.